### PR TITLE
Improvements state-absent config

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ you to do so by making a [pull](../../pulls) request or submitting an [issue](..
 
 * [Adam Dyson](https://github.com/adamdyson)
 * [Evgeny Lebedev](https://github.com/lebe-dev)
+* [Jørgen van der Meulen](https://github.com/jvandermeulen)
 
 ## License
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,7 +12,9 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ logrotate_config_files }}'
-  when: 'logrotate_config_files | default(None) != None'
+    - 'logrotate_config_files | default(None) != None'
+    - 'item.paths is defined'
+
 
 - name: 'Logrotate | Configure absent config files.'
   become: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,6 +12,7 @@
     group: 'root'
     mode: '0644'
   with_items: '{{ logrotate_config_files }}'
+  when:
     - 'logrotate_config_files | default(None) != None'
     - 'item.paths is defined'
 

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -4,19 +4,17 @@
 {{ path }}
 {% endfor %}
 {
-	
-	{% if item.options is defined %}
-	{% for option in item.options %}
-	{{ option }}
-	{% endfor %}
-	{% endif %}
-	
-	{% if item.scripts is defined %}
-	{% for name, script in item.scripts.iteritems() %}
-	{{ name }}
-		{{ script }}
-	endscript
-	{% endfor %}
-	{% endif %}
-	
+{% if item.options is defined %}
+{% for option in item.options %}
+    {{ option }}
+{% endfor %}
+{% endif %}
+
+{% if item.scripts is defined %}
+{% for name, script in item.scripts.iteritems() %}
+    {{ name }}
+        {{ script }}
+    endscript
+{% endfor %}
+{% endif %}
 }


### PR DESCRIPTION
Improve usability of logrotation configs that should be removed (state: 'absent') and have no 'paths' configured and used to fail. The 'absent' example shown in the docs now work as intended.
Resolve indentation on first line of logrotate options.